### PR TITLE
P2022-1506 Prepare landspace layout/view

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,4 +44,5 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     implementation("androidx.cardview:cardview:1.0.0")
+    implementation 'com.android.support:design:32.0.0'
 }

--- a/app/src/main/res/drawable/login_edit_text.xml
+++ b/app/src/main/res/drawable/login_edit_text.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <solid android:color="#272233"/>
-    <stroke
-        android:width="1.5dp"
-        android:color="#3B334C" />
-    <corners
-        android:radius="10dp" />
-</shape>

--- a/app/src/main/res/drawable/login_edit_text_green.xml
+++ b/app/src/main/res/drawable/login_edit_text_green.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:state_enabled="true" android:state_focused="true">
+        <shape android:shape="rectangle">
+            <solid android:color="#272233"/>
+            <stroke
+                android:width="1.5dp"
+                android:color="@color/green" />
+            <corners
+                android:radius="10dp" />
+        </shape>
+    </item>
+
+    <item android:state_enabled="true" >
+        <shape android:shape="rectangle">
+            <solid android:color="#272233"/>
+            <stroke
+                android:width="1.5dp"
+                android:color="#3B334C" />
+            <corners
+                android:radius="10dp" />
+        </shape>
+    </item>
+
+</selector>

--- a/app/src/main/res/layout-land/activity_details.xml
+++ b/app/src/main/res/layout-land/activity_details.xml
@@ -1,0 +1,268 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+xmlns:app="http://schemas.android.com/apk/res-auto"
+xmlns:tools="http://schemas.android.com/tools"
+android:layout_width="match_parent"
+android:layout_height="match_parent"
+android:background="@drawable/details_photo"
+tools:context=".DetailsActivity">
+
+<com.google.android.material.appbar.AppBarLayout
+    android:id="@+id/appBarLayout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_marginBottom="100dp"
+    android:fitsSystemWindows="true">
+
+    <com.google.android.material.appbar.CollapsingToolbarLayout
+        android:id="@+id/collapsing_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fitsSystemWindows="true"
+        app:layout_scrollFlags="scroll|snap|exitUntilCollapsed">
+        <ImageView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:srcCompat="@drawable/details_photo"
+            android:scaleType="centerCrop"
+            android:scrollY="-30dp"
+            tools:ignore="ContentDescription"
+            app:layout_collapseMode="parallax">
+        </ImageView>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/details_screen_toolbar_height">
+
+            <androidx.appcompat.widget.Toolbar
+                android:id="@+id/detailsScreenToolbar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:minHeight="?attr/actionBarSize"
+                android:theme="?attr/actionBarTheme"
+                app:elevation="3dp"
+                android:background="@drawable/gradient_background"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <RelativeLayout
+                android:id="@+id/toolbarCircleBack"
+                android:layout_width="@dimen/toolbar_circle_width"
+                android:layout_height="@dimen/toolbar_circle_width"
+                android:layout_alignParentStart="true"
+                android:layout_alignParentTop="true"
+                android:layout_marginStart="@dimen/toolbar_circle_margin_left_right"
+                android:layout_marginTop="@dimen/toolbar_circle_margin_top"
+                android:background="@drawable/ic_toolbar_circle"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <ImageView
+                    android:id="@+id/imageViewBackArrow"
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    android:layout_alignParentStart="true"
+                    android:layout_alignParentTop="true"
+                    android:layout_alignParentEnd="true"
+                    android:layout_alignParentBottom="true"
+                    android:contentDescription="@string/backArrow"
+                    android:padding="@dimen/toolbar_back_arrow_padding"
+                    app:srcCompat="@drawable/ic_chevron_left" />
+            </RelativeLayout>
+
+            <RelativeLayout
+                android:id="@+id/toolbarCircleFavourite"
+                android:layout_width="@dimen/toolbar_circle_width"
+                android:layout_height="@dimen/toolbar_circle_width"
+                android:layout_alignParentTop="true"
+                android:layout_alignParentEnd="true"
+                android:layout_marginTop="@dimen/toolbar_circle_margin_top"
+                android:layout_marginEnd="@dimen/toolbar_circle_margin_left_right"
+                android:background="@drawable/ic_toolbar_circle"
+                app:layout_constraintEnd_toEndOf="@+id/detailsScreenToolbar"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <ImageView
+                    android:id="@+id/imageViewHeart"
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    android:layout_alignParentStart="true"
+                    android:layout_alignParentTop="true"
+                    android:layout_alignParentEnd="true"
+                    android:layout_alignParentBottom="true"
+                    android:contentDescription="@string/heartIcon"
+                    android:padding="@dimen/toolbar_heart_icon_padding"
+                    android:src="@drawable/ic_favourite" />
+            </RelativeLayout>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </com.google.android.material.appbar.CollapsingToolbarLayout>
+
+</com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@drawable/details_background"
+        app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior">
+
+        <RelativeLayout
+            android:id="@+id/detailsLayout"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/detailsLayoutHeight"
+            android:orientation="vertical"
+            android:background="@drawable/details_background"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent">
+
+            <TextView
+                android:id="@+id/detailsTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/detailsStartMargin"
+                android:layout_marginTop="@dimen/detailsTitleTopMargin"
+                android:fontFamily="@font/inter_medium"
+                android:text="@string/detailsTitleText"
+                android:textColor="@color/white"
+                android:textSize="@dimen/detailsTitleTextSize"
+                app:lineHeight="32dp" />
+
+            <RelativeLayout
+                android:id="@+id/infoLayout"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/detailsLineHeight"
+                android:layout_marginTop="@dimen/detailsInfoTopMargin"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/details_year_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/detailsStartMargin"
+                    android:fontFamily="@font/inter_semibold"
+                    android:text="@string/detailsYearText"
+                    android:textColor="@color/white"
+                    android:textSize="@dimen/detailsInfoTextSize"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:lineHeight="@dimen/detailsLineHeight" />
+
+                <ImageView
+                    android:id="@+id/detailsCircle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:srcCompat="@drawable/circle_shape"
+                    tools:ignore="ContentDescription"
+                    android:layout_toEndOf="@+id/details_year_text"
+                    android:layout_marginStart="@dimen/detailsStartMargin"
+                    android:layout_marginTop="@dimen/detailsCircleMarginTop"/>
+
+                <TextView
+                    android:id="@+id/detailsSeasonsText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/detailsStartMargin"
+                    android:layout_toEndOf="@+id/detailsCircle"
+                    android:fontFamily="@font/inter_semibold"
+                    android:text="@string/detailsSeasonsText"
+                    android:textColor="@color/white"
+                    android:textSize="@dimen/detailsInfoTextSize"
+                    app:lineHeight="@dimen/detailsLineHeight" />
+
+                <ImageView
+                    android:id="@+id/detailsCircle2"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:srcCompat="@drawable/circle_shape"
+                    tools:ignore="ContentDescription"
+                    android:layout_toEndOf="@+id/detailsSeasonsText"
+                    android:layout_marginStart="@dimen/detailsStartMargin"
+                    android:layout_marginTop="@dimen/detailsCircleMarginTop" />
+
+                <TextView
+                    android:id="@+id/detailsPGText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/detailsStartMargin"
+                    android:text="@string/detailsPGText"
+                    android:textSize="@dimen/detailsInfoTextSize"
+                    android:fontFamily="@font/inter_semibold"
+                    android:layout_toEndOf="@+id/detailsCircle2"
+                    app:lineHeight="@dimen/detailsLineHeight"
+                    android:textColor="@color/white"/>
+
+            </RelativeLayout>
+
+            <TextView
+                android:id="@+id/detailsDescriptionText"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/detailsDescriptionTextHeight"
+                android:layout_gravity="center"
+                android:layout_marginHorizontal="@dimen/detailsStartMargin"
+                android:layout_marginTop="@dimen/detailsDescriptionMarginTop"
+                android:fontFamily="@font/inter"
+                android:text="@string/detailsDescriptionText"
+                android:textColor="@color/gray_20"
+                android:textSize="@dimen/detailsInfoTextSize"
+                app:lineHeight="@dimen/detailsLineHeight" />
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="112dp"
+                android:layout_below="@+id/detailsDescriptionText"
+                android:background="@drawable/button_background">
+
+                <RelativeLayout
+                    android:id="@+id/detailsButtonLayout"
+                    android:layout_width="match_parent"
+                    android:layout_height="64dp"
+                    android:orientation="horizontal"
+                    android:layout_marginHorizontal="@dimen/detailsStartMargin"
+                    app:layout_constraintLeft_toLeftOf="@+id/watchButton"
+                    app:layout_constraintTop_toTopOf="@+id/watchButton"
+                    app:layout_constraintRight_toRightOf="@id/watchButton"
+                    app:layout_constraintBottom_toBottomOf="@id/watchButton"
+                    android:gravity="center"
+                    android:elevation="3dp">
+
+                    <ImageView
+                        android:id="@+id/details_button_chevron"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="13dp"
+                        android:layout_marginTop="5dp"
+                        android:layout_marginEnd="13dp"
+                        android:layout_toStartOf="@+id/details_button_text"
+                        app:srcCompat="@drawable/ic_chevronright"
+                        tools:ignore="ContentDescription" />
+
+                    <TextView
+                        android:id="@+id/details_button_text"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/detailsWatchButtonText"
+                        android:textSize="16sp"
+                        android:fontFamily="@font/inter_semibold"
+                        app:layout_constraintLeft_toLeftOf="parent"
+                        app:lineHeight = "20dp"
+                        android:textColor="@color/black" />
+
+                </RelativeLayout>
+
+                <Button
+                    android:id="@+id/watchButton"
+                    android:layout_marginHorizontal="@dimen/detailsStartMargin"
+                    app:cornerRadius="@dimen/detailsWatchButtonCornerRadius"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    style="@style/logInUpButton"
+                    />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+        </RelativeLayout>
+
+    </androidx.core.widget.NestedScrollView>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout-land/activity_login.xml
+++ b/app/src/main/res/layout-land/activity_login.xml
@@ -40,7 +40,7 @@
       android:id="@+id/tabLayout"
       android:layout_width="@dimen/tabLayoutWidth"
       android:layout_height="wrap_content"
-      android:layout_marginTop="@dimen/tabLayoutMarginTop"
+      android:layout_marginTop="15dp"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toBottomOf="@+id/header_bar"
       app:tabIndicatorColor="@color/green"

--- a/app/src/main/res/layout-land/activity_reset_password.xml
+++ b/app/src/main/res/layout-land/activity_reset_password.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ResetPasswordActivity">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appBarLayoutResetPassword"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/details_screen_toolbar_height"
+        android:background="@android:color/transparent"
+        app:elevation="0dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <androidx.appcompat.widget.Toolbar
+                android:id="@+id/resetPasswordToolbar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <ImageView
+                android:id="@+id/imageViewResetPasswordBack"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="17.33dp"
+                android:layout_marginTop="18.67dp"
+                android:contentDescription="@string/backArrow"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:srcCompat="@drawable/ic_chevron_left_stroke" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <ScrollView
+        android:id="@+id/scrollView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginTop="@dimen/details_screen_toolbar_height">
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:id="@+id/textViewResetPasswordd"
+                android:layout_width="wrap_content"
+                android:layout_height="32dp"
+                android:layout_marginStart="@dimen/loginMarginHorizontal"
+                android:layout_marginTop="48dp"
+                android:fontFamily="@font/inter_medium"
+                android:lineSpacingExtra="8sp"
+                android:text="@string/resetPassword"
+                android:textColor="#DEE2E2"
+                android:textSize="20sp"
+                android:translationY="-3.9sp"/>
+
+            <EditText
+                android:id="@+id/editTextResetPassword"
+                style="@style/loginEditText"
+                android:layout_below="@+id/textViewResetPasswordd"
+                android:layout_marginHorizontal="@dimen/loginMarginHorizontal"
+                android:layout_marginTop="30dp"
+                android:autofillHints=""
+                android:hint="@string/passwordEditTextHint"
+                android:inputType="textPassword" />
+
+            <ImageView
+                android:id="@+id/imageViewShowPassword"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/editTextResetPassword"
+                android:layout_alignEnd="@+id/editTextResetPassword"
+                android:layout_marginTop="-44dp"
+                android:layout_marginEnd="22dp"
+                android:contentDescription="@string/show_password"
+                android:src="@drawable/ic_show_password" />
+
+            <EditText
+                android:id="@+id/editTextResetPassword2"
+                style="@style/loginEditText"
+                android:layout_below="@+id/editTextResetPassword"
+                android:layout_marginHorizontal="@dimen/loginMarginHorizontal"
+                android:layout_marginTop="@dimen/loginPasswordMarginTop"
+                android:autofillHints=""
+                android:hint="@string/re_enter_new_password"
+                android:inputType="textPassword"
+                tools:ignore="RtlSymmetry"/>
+
+            <Button
+                android:id="@+id/buttonResetPassword"
+                android:layout_marginHorizontal="@dimen/loginMarginHorizontal"
+                android:text="@string/resetPassword"
+                app:cornerRadius="@dimen/detailsWatchButtonCornerRadius"
+                android:layout_below="@+id/editTextResetPassword2"
+                android:layout_marginTop="@dimen/loginPasswordTextMarginTop"
+                style="@style/logInUpButton"
+                tools:ignore="DuplicateSpeakableTextCheck"/>
+
+        </RelativeLayout>
+    </ScrollView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout-land/fragment_sign_in.xml
+++ b/app/src/main/res/layout-land/fragment_sign_in.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".Fragments.SignInFragment">
+
+    <ScrollView
+        android:id="@+id/scrollView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            tools:layout_editor_absoluteX="-39dp"
+            tools:layout_editor_absoluteY="-134dp">
+
+            <EditText
+                android:id="@+id/loginEditText"
+                android:layout_marginHorizontal="@dimen/loginMarginHorizontal"
+                android:layout_marginTop="@dimen/loginEmailMarginTop"
+                android:hint = "@string/loginEditTextHint"
+                android:inputType="text"
+                style="@style/loginEditText"/>
+
+            <EditText
+                android:id="@+id/passwordEditText"
+                android:layout_below="@id/loginEditText"
+                android:layout_marginHorizontal="@dimen/loginMarginHorizontal"
+                android:layout_marginTop="@dimen/loginPasswordMarginTop"
+                android:hint="@string/passwordEditTextHint"
+                android:inputType="textPassword"
+                style="@style/loginEditText"/>
+
+            <TextView
+                android:id="@+id/forgotpassText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/passwordEditText"
+                android:layout_marginStart="@dimen/loginMarginHorizontal"
+                android:layout_marginTop="@dimen/loginPasswordTextMarginTop"
+                android:fontFamily="@font/inter"
+                android:text="@string/forgotPasswordText"
+                android:textColor="@color/green"
+                android:textSize="@dimen/loginPasswordTextSize" />
+
+            <Button
+                android:id="@+id/signInButton"
+                android:layout_marginHorizontal="@dimen/loginMarginHorizontal"
+                android:text="@string/signInButtonText"
+                app:cornerRadius="@dimen/detailsWatchButtonCornerRadius"
+                android:layout_below="@+id/forgotpassText"
+                android:layout_marginTop="@dimen/loginPasswordTextMarginTop"
+                style="@style/logInUpButton"/>
+
+        </RelativeLayout>
+
+    </ScrollView>
+
+</FrameLayout>

--- a/app/src/main/res/layout-land/fragment_sign_up.xml
+++ b/app/src/main/res/layout-land/fragment_sign_up.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".Fragments.SignUpFragment">
+
+    <ScrollView
+        android:id="@+id/scrollView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            tools:layout_editor_absoluteX="-39dp"
+            tools:layout_editor_absoluteY="-134dp">
+
+            <EditText
+                android:id="@+id/loginEditText"
+                android:layout_marginHorizontal="@dimen/loginMarginHorizontal"
+                android:layout_marginTop="@dimen/loginEmailMarginTop"
+                android:hint = "@string/loginEditTextHint"
+                android:inputType="text"
+                style="@style/loginEditText"/>
+
+            <EditText
+                android:id="@+id/passwordEditText"
+                android:layout_below="@id/loginEditText"
+                android:layout_marginHorizontal="@dimen/loginMarginHorizontal"
+                android:layout_marginTop="@dimen/loginPasswordMarginTop"
+                android:hint="@string/passwordEditTextHint"
+                android:inputType="textPassword"
+                style="@style/loginEditText"/>
+
+            <EditText
+                android:id="@+id/repeatPassword"
+                android:layout_below="@id/passwordEditText"
+                android:layout_marginHorizontal="@dimen/loginMarginHorizontal"
+                android:layout_marginTop="@dimen/loginPasswordMarginTop"
+                android:hint="@string/repeatPassEditTextHint"
+                android:inputType="textPassword"
+                style="@style/loginEditText"/>
+
+            <Button
+                android:id="@+id/signUpButton"
+                android:layout_marginHorizontal="@dimen/loginMarginHorizontal"
+                android:text="@string/signUpButtonText"
+                app:cornerRadius="@dimen/detailsWatchButtonCornerRadius"
+                android:layout_below="@+id/repeatPassword"
+                android:layout_marginTop="@dimen/loginPasswordTextMarginTop"
+                style="@style/logInUpButton"/>
+
+        </RelativeLayout>
+
+    </ScrollView>
+
+</FrameLayout>

--- a/app/src/main/res/layout/activity_reset_password.xml
+++ b/app/src/main/res/layout/activity_reset_password.xml
@@ -99,14 +99,14 @@
         app:layout_constraintTop_toBottomOf="@+id/editTextResetPassword"
         tools:ignore="RtlSymmetry" />
 
-    <androidx.appcompat.widget.AppCompatButton
+    <Button
         android:id="@+id/buttonResetPassword"
-        style="@style/logInUpButton"
-        android:layout_marginHorizontal="@dimen/loginMarginHorizontal"
+        android:layout_marginHorizontal="@dimen/detailsStartMargin"
         android:text="@string/resetPassword"
+        app:cornerRadius="@dimen/detailsWatchButtonCornerRadius"
+        app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        tools:ignore="DuplicateSpeakableTextCheck" />
+        tools:ignore="DuplicateSpeakableTextCheck"
+        style="@style/logInUpButton" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_sign_in.xml
+++ b/app/src/main/res/layout/fragment_sign_in.xml
@@ -38,7 +38,7 @@
             android:layout_marginTop="@dimen/loginPasswordTextMarginTop"
             android:fontFamily="@font/inter"
             android:text="@string/forgotPasswordText"
-            android:textColor="@color/greenAccents"
+            android:textColor="@color/green"
             android:textSize="@dimen/loginPasswordTextSize" />
 
     </RelativeLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -12,5 +12,5 @@
     <color name="steel_grey">#272233</color>
     <color name="divider_color">#3B334C</color>
     <color name="gray_20">#D2D2D2</color>
-    <color name="greenAccents">#44EC52</color>
+    <color name="grey_white">#DEE2E2</color>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -41,7 +41,7 @@
         <item name="android:layout_marginBottom">24dp</item>
         <item name="android:backgroundTint">#FFFFFF</item>
         <item name="android:fontFamily">@font/inter_semibold</item>
-        <item name="android:padding">16dp</item>
+        <item name="android:padding">15dp</item>
         <item name="android:textColor">#1E1B26</item>
         <item name="android:textSize">16sp</item>
         <item name="android:textAllCaps">false</item>
@@ -50,7 +50,7 @@
     <style name="loginEditText">
         <item name="android:layout_height">@dimen/editTextHeight</item>
         <item name="android:layout_width">match_parent</item>
-        <item name="android:background">@drawable/login_edit_text</item>
+        <item name="android:background">@drawable/login_edit_text_green</item>
         <item name="android:padding">20dp</item>
         <item name="android:fontFamily">@font/inter</item>
         <item name="android:textSize">16sp</item>


### PR DESCRIPTION
Creates landspace for: activity_details, activity_login, activity_reset_password, fragment_sign_in, fragment_sign_up.

Removes repeating color.

Changing the button padding to incompatible with the design. Padding of the size given in the design cut off a piece of the text for smaller phones.

Adds highlighting edit text in login files.
