### PR TITLE
P2022-2026/Temporary fix for API 29+

### DIFF
--- a/app/src/main/java/com/intive/patronage22/intivi/DetailsActivity.kt
+++ b/app/src/main/java/com/intive/patronage22/intivi/DetailsActivity.kt
@@ -1,6 +1,7 @@
 package com.intive.patronage22.intivi
 
 import android.content.Intent
+import android.os.Build
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.view.WindowManager
@@ -20,6 +21,7 @@ class DetailsActivity : AppCompatActivity() {
         findViewById<Button>(R.id.watchButton).setOnClickListener{
             startActivity(Intent(this, VideoPlayerActivity::class.java))
         }
-        this.window.setFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS, WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
+
+        if (Build.VERSION.SDK_INT < 29) this.window.setFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS, WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
     }
 }

--- a/app/src/main/java/com/intive/patronage22/intivi/LoginActivity.kt
+++ b/app/src/main/java/com/intive/patronage22/intivi/LoginActivity.kt
@@ -1,8 +1,13 @@
 package com.intive.patronage22.intivi
 
+import android.os.Build
 import android.os.Bundle
 import android.view.WindowManager
+import android.widget.FrameLayout
 import androidx.appcompat.app.AppCompatActivity
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
@@ -32,6 +37,6 @@ class LoginActivity : AppCompatActivity() {
             }
         }.attach()
 
-        this.window.setFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS, WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
+        if (Build.VERSION.SDK_INT < 29) this.window.setFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS, WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
     }
 }

--- a/app/src/main/java/com/intive/patronage22/intivi/MainActivity.kt
+++ b/app/src/main/java/com/intive/patronage22/intivi/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.intive.patronage22.intivi
 
+import android.os.Build
 import android.os.Bundle
 import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
@@ -38,6 +39,6 @@ class MainActivity : AppCompatActivity() {
             }
         }.attach()
 
-       this.window.setFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS, WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
+        if (Build.VERSION.SDK_INT < 29) this.window.setFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS, WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
     }
 }

--- a/app/src/main/java/com/intive/patronage22/intivi/ResetPasswordActivity.kt
+++ b/app/src/main/java/com/intive/patronage22/intivi/ResetPasswordActivity.kt
@@ -2,11 +2,13 @@ package com.intive.patronage22.intivi
 
 import android.content.Intent
 import android.graphics.drawable.Drawable
+import android.os.Build
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.text.method.HideReturnsTransformationMethod
 import android.text.method.PasswordTransformationMethod
 import android.view.View
+import android.view.WindowManager
 import android.widget.Button
 import android.widget.EditText
 import android.widget.ImageView
@@ -29,5 +31,7 @@ class ResetPasswordActivity : AppCompatActivity() {
                 startActivity(Intent(applicationContext, LoginActivity::class.java))
             }.start()
         }
+
+        if (Build.VERSION.SDK_INT < 29) this.window.setFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS, WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
     }
 }

--- a/app/src/main/java/com/intive/patronage22/intivi/VideoPlayerActivity.kt
+++ b/app/src/main/java/com/intive/patronage22/intivi/VideoPlayerActivity.kt
@@ -8,20 +8,15 @@ import android.view.WindowInsets
 import android.view.WindowManager
 import android.widget.ImageView
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 
 class VideoPlayerActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
-        application.setTheme(R.style.LightTheme)
         super.onCreate(savedInstanceState)
-        @Suppress("DEPRECATION")
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            window.insetsController?.hide(WindowInsets.Type.statusBars())
-        } else {
-            window.setFlags(
-                WindowManager.LayoutParams.FLAG_FULLSCREEN,
-                WindowManager.LayoutParams.FLAG_FULLSCREEN
-            )
-        }
+        val controller = WindowInsetsControllerCompat(window, window.decorView)
+        controller.hide(WindowInsetsCompat.Type.systemBars())
+        controller.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
         setContentView(R.layout.activity_video_player)
 
         findViewById<ImageView>(R.id.close_video).setOnClickListener{

--- a/app/src/main/res/layout-land/activity_login.xml
+++ b/app/src/main/res/layout-land/activity_login.xml
@@ -3,6 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".LoginActivity">

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -3,6 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".LoginActivity">

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -15,4 +15,5 @@
     <color name="grey_white">#DEE2E2</color>
     <color name="greyscale">#E9E9E9</color>
     <color name="greyed_out">#808080</color>
+    <color name="transparent">#00FFFFFF</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -15,5 +15,4 @@
     <color name="grey_white">#DEE2E2</color>
     <color name="greyscale">#E9E9E9</color>
     <color name="greyed_out">#808080</color>
-    <color name="transparent">#00FFFFFF</color>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -16,7 +16,7 @@
         <item name="android:editTextColor">@color/greyscale</item>
         <item name="android:textColor">@color/greyscale</item>
         <item name="android:textColorHint">@color/greyscale</item>
-        <item name="android:forceDarkAllowed" tools:targetApi="q">true</item>
+        <item name="android:forceDarkAllowed" tools:targetApi="q">false</item>
         <item name="android:windowDrawsSystemBarBackgrounds">false</item>
         <item name="android:windowTranslucentStatus">true</item>
         <item name="android:navigationBarColor">@color/black</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -10,16 +10,16 @@
         <item name="colorSecondary">@color/green</item>
         <item name="colorSecondaryVariant">@color/teal_700</item>
         <item name="colorOnSecondary">@color/black</item>
-        <!-- Status bar color. -->
-        <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->
         <item name="android:windowBackground">@color/bastille</item>
         <item name="editTextColor">@color/greyscale</item>
         <item name="android:editTextColor">@color/greyscale</item>
         <item name="android:textColor">@color/greyscale</item>
         <item name="android:textColorHint">@color/greyscale</item>
-        <item name="android:forceDarkAllowed" tools:targetApi="q">false</item>
+        <item name="android:forceDarkAllowed" tools:targetApi="q">true</item>
         <item name="android:windowDrawsSystemBarBackgrounds">false</item>
         <item name="android:windowTranslucentStatus">true</item>
+        <item name="android:navigationBarColor">@color/black</item>
+        <item name="android:fitsSystemWindows">true</item>
     </style>
 </resources>


### PR DESCRIPTION
PR#2
Fixed system bars overlapping for API 29+

TODO: Find a backwards compatible way to achieve status bar transparency for API 29+


API < 29
![transparent status bar](https://user-images.githubusercontent.com/98414007/161425669-be755595-4f3c-4df6-8fa0-e56711462e85.JPG)


API >= 29
![api 29](https://user-images.githubusercontent.com/98414007/161425682-4836561a-ea0c-435c-8cba-c45901fa7a2d.JPG)

Collapsing system bars. (Later can be set to show when video is paused, along with other UI elements.)
![collapsing system bars](https://user-images.githubusercontent.com/98414007/161425686-b1730848-7324-463c-926e-bec3ec1585fc.JPG)

